### PR TITLE
Update Ngrok Url for Consist Domain Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ You will see a url under the `Forwarding`row that --> to your localhost. Copy th
 
 ### Call the number and chat to your bot.
 
-7. You can call your Twilio phone number directly. Alternatively, make the call with the following, where `+123456789` is the Twilio number you bought and `+19876543210` is your phone number and `abcdef.ngrok.app` is your ngrok host.
+7. You can call your Twilio phone number directly. Alternatively, make the call with the following, where `+123456789` is the Twilio number you bought and `+19876543210` is your phone number and `abcdef.ngrok-free.app` is your ngrok host.
 
 ```sh
-twilio api:core:calls:create --from="+123456789" --to="+19876543210" --url="https://abcdef.ngrok.app/twiml"
+twilio api:core:calls:create --from="+123456789" --to="+19876543210" --url="https://abcdef.ngrok-free.app/twiml"
 ```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ ngrok http 8080
 
 You will see a url under the `Forwarding`row that --> to your localhost. Copy this as the `<ngrok url>`
 
-5. Edit the [templates/streams](templates/streams.xml) file to replace `<ngrok url>` with your ngrok host. Example: `wss://abcdef.ngrok.io/streams`. Remember to use `wss://` and include `/streams` in the url 
+5. Edit the [templates/streams](templates/streams.xml) file to replace `<ngrok url>` with your ngrok host. Example: `wss://abcdef.ngrok-free.app/streams`. Remember to use `wss://` and include `/streams` in the url 
 
 6. Go to your Twilio page where you manage your phone number. Under the Configure tab, replace the webhook URL where the call comes in to your ngrok url. Example: `https://abcdef.ngrok-free.app/twiml` . Remember to use `https://` and include `/twiml`
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ You will see a url under the `Forwarding`row that --> to your localhost. Copy th
 
 ### Call the number and chat to your bot.
 
-7. You can call your Twilio phone number directly. Alternatively, make the call with the following, where `+123456789` is the Twilio number you bought and `+19876543210` is your phone number and `abcdef.ngrok.io` is your ngrok host.
+7. You can call your Twilio phone number directly. Alternatively, make the call with the following, where `+123456789` is the Twilio number you bought and `+19876543210` is your phone number and `abcdef.ngrok.app` is your ngrok host.
 
 ```sh
-twilio api:core:calls:create --from="+123456789" --to="+19876543210" --url="https://abcdef.ngrok.io/twiml"
+twilio api:core:calls:create --from="+123456789" --to="+19876543210" --url="https://abcdef.ngrok.app/twiml"
 ```


### PR DESCRIPTION
Use consistent ngrok-free.app domain usage across ngrok_url.

https://github.com/deepgram/deepgram-twilio-streaming-voice-agent/issues/9